### PR TITLE
fixes on the do_download scripts for CMIP6 and SEAS5

### DIFF
--- a/icenet/download_cmip6_data.py
+++ b/icenet/download_cmip6_data.py
@@ -328,19 +328,19 @@ for variable_id, variable_id_dict in source_id_dict['variable_dict'].items():
                 print('skipping this plevel due to existing file {}'.format(fpaths_EASE[plevel]), end='', flush=True)
                 continue
 
-                print('loading metadata... ', end='', flush=True)
+            print('loading metadata... ', end='', flush=True)
 
-                # Avoid 500MB DAP request limit
-                cmip6_da = xr.open_mfdataset(results, combine='by_coords', chunks={'time': '499MB'})[variable_id]
+            # Avoid 500MB DAP request limit
+            cmip6_da = xr.open_mfdataset(results, combine='by_coords', chunks={'time': '499MB'})[variable_id]
 
-                if plevel is not None:
-                    cmip6_da = cmip6_da.sel(plev=plevel)
+            if plevel is not None:
+                cmip6_da = cmip6_da.sel(plev=plevel)
 
-                print('downloading with xarray... ', end='', flush=True)
-                cmip6_da.compute()
+            print('downloading with xarray... ', end='', flush=True)
+            cmip6_da.compute()
 
-                print('saving to regrid in iris... ', end='', flush=True)
-                cmip6_da.to_netcdf(fpaths_latlon[plevel])
+            print('saving to regrid in iris... ', end='', flush=True)
+            cmip6_da.to_netcdf(fpaths_latlon[plevel])
 
     if do_regrid:
         for plevel in variable_id_dict['plevels']:

--- a/icenet/download_seas5_forecasts.py
+++ b/icenet/download_seas5_forecasts.py
@@ -62,7 +62,7 @@ init_dates = [date.strftime('%Y-%m-%d') for date in init_dates]
 
 server = ECMWFService("mars", url="https://api.ecmwf.int/v1",
                       key=config.ECMWF_API_KEY,
-                      email=config.EMCWF_API_EMAIL)
+                      email=config.ECMWF_API_EMAIL)
 
 request_dict = {
     'class': 'od',  # For hi-res SEAS5 data (as opposed to 'c3')
@@ -122,13 +122,14 @@ if do_download:
 
     if os.path.exists(download_path) and not overwrite:
         print('File exists - skipping.')
-
+        do_download = False #change do_download so that we do not attempt to download
     elif os.path.exists(download_path) and overwrite:
         print('Deleting existing file.')
         os.remove(download_path)
+        do_download = True #for clarity
 
-    # File doesn't exist (or was just deleted)
-    else:
+    # File doesn't exist (or will be overwritten)
+    if do_download:
         server.execute(request_dict, download_path)
 
         dur = time.time() - tic


### PR DESCRIPTION
The current scripts to download the CMIP6 datasets and SEAS5 forecast data do not work, which leads to IO errors during the regrid phase This request provides a small fix to them so that they run as intended.

